### PR TITLE
Update Telekom password rule

### DIFF
--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -196,7 +196,7 @@
         "password-rules": "minlength: 8; maxlength: 16;"
     },
     "telekom-dienste.de": {
-        "password-rules": "minlength: 8; maxlength: 16;"
+        "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [#$%&()*+,./<=>?@_{|}~];"
     },
     "ubisoft.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-]; required: [!@#$%^&*()+];"


### PR DESCRIPTION
As shown in the screenshot from their [registration site](https://meinkonto.telekom-dienste.de/telekom/email/registration/registration.xhtml) their requirements go beyond 8-16 characters:

![Bildschirmfoto 2020-06-06 um 15 10 08](https://user-images.githubusercontent.com/27491477/83945353-5e181f80-a80a-11ea-9839-7a17281e7eb1.png)
